### PR TITLE
Add Google Analytics tag

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -26,6 +26,19 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* Google tag (gtag.js) */}
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLTZMFB49W"></script>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-TLTZMFB49W');
+            `,
+          }}
+        />
         <link rel="icon" href="/favicon.ico" />
         <link
           rel="apple-touch-icon"


### PR DESCRIPTION
## Summary
- embed Google Analytics (gtag.js) snippet after the `<head>` tag in the root layout so all pages load tracking script

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (starts Next.js, shows duplicate page warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a3e4c90484832482371dc894631f56