### PR TITLE
Integrate GTM and add noscript fallback

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,4 +1,5 @@
 import { Inter } from "next/font/google";
+import Script from "next/script";
 import ClientLayout from "../components/ClientLayout";
 import "./globals.css";
 
@@ -26,19 +27,15 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Google tag (gtag.js) */}
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-TLTZMFB49W"></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-TLTZMFB49W');
-            `,
-          }}
-        />
+        <Script id="google-tag-manager" strategy="afterInteractive">
+          {`
+            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','G-TLTZMFB49W');
+          `}
+        </Script>
         <link rel="icon" href="/favicon.ico" />
         <link
           rel="apple-touch-icon"
@@ -63,6 +60,14 @@ export default function RootLayout({ children }) {
         <meta name="theme-color" content="#ffffff" />
       </head>
       <body className={inter.className} suppressHydrationWarning>
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=G-TLTZMFB49W"
+            height="0"
+            width="0"
+            style={{ display: "none", visibility: "hidden" }}
+          ></iframe>
+        </noscript>
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- replace GA4 scripts in `app/layout.jsx` with Google Tag Manager setup
- add noscript fallback iframe for GTM
- use real GTM container ID `G-TLTZMFB49W`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Duplicate page detected and dev server start)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ea8d0764832484ce26e5146d44a6