### PR TITLE
feat: track page views via AnalyticsListener

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,5 +1,6 @@
 import { Inter } from "next/font/google";
 import ClientLayout from "../components/ClientLayout";
+import AnalyticsListener from "../components/AnalyticsListener";
 import "./globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -63,6 +64,7 @@ export default function RootLayout({ children }) {
         <meta name="theme-color" content="#ffffff" />
       </head>
       <body className={inter.className} suppressHydrationWarning>
+        <AnalyticsListener />
         <ClientLayout>{children}</ClientLayout>
       </body>
     </html>

--- a/components/AnalyticsListener.jsx
+++ b/components/AnalyticsListener.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+export default function AnalyticsListener() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "page_view",
+        page_path: pathname,
+      });
+    }
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add `AnalyticsListener` client component that pushes `page_view` events to `dataLayer` on route changes
- include listener in root layout so analytics events fire on every navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3ea92aa0c83248d23ab508286e58b