### PR TITLE
Replace gtag with GTM snippet

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -28,18 +28,17 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Google tag (gtag.js) */}
-        <Script
-          strategy="afterInteractive"
-          src="https://www.googletagmanager.com/gtag/js?id=G-TLTZMFB49W"
-        />
-        <Script id="gtag-init" strategy="afterInteractive">
+        <Script id="google-tag-manager" strategy="afterInteractive">
           {`
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-TLTZMFB49W');
+            (function(w,d,s,l,i){
+              w[l]=w[l]||[];
+              w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+              var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+              j.async=true;
+              j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+              f.parentNode.insertBefore(j,f);
+            })(window,document,'script','dataLayer','GTM-XXXXXXX');
           `}
         </Script>
         <link rel="icon" href="/favicon.ico" />
@@ -66,6 +65,14 @@ export default function RootLayout({ children }) {
         <meta name="theme-color" content="#ffffff" />
       </head>
       <body className={inter.className} suppressHydrationWarning>
+        <noscript>
+          <iframe
+            src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX"
+            height="0"
+            width="0"
+            style={{ display: "none", visibility: "hidden" }}
+          ></iframe>
+        </noscript>
         <AnalyticsListener />
         <ClientLayout>{children}</ClientLayout>
       </body>


### PR DESCRIPTION
## Summary
- swap Google Analytics gtag.js for Google Tag Manager snippet with noscript fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(warn: Duplicate page detected; dev server started)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fb565f648324bd68e21ec481a3b8